### PR TITLE
NXP-10546: NXQLQueryBuilder still appends quotes on null values when 'quoteParameters' is disabled

### DIFF
--- a/nuxeo-platform-query-api/src/main/java/org/nuxeo/ecm/platform/query/nxql/NXQLQueryBuilder.java
+++ b/nuxeo-platform-query-api/src/main/java/org/nuxeo/ecm/platform/query/nxql/NXQLQueryBuilder.java
@@ -181,7 +181,9 @@ public class NXQLQueryBuilder {
                     }
                 } else {
                     if (params[i] == null) {
-                        queryBuilder.append("''");
+                        if (quoteParameters) {
+                        	queryBuilder.append("''");
+                        }
                     } else {
                         String queryParam = params[i].toString();
                         queryBuilder.append(prepareStringLiteral(queryParam,

--- a/nuxeo-platform-query-api/src/test/java/org/nuxeo/ecm/platform/query/api/TestNXQLQueryBuilder.java
+++ b/nuxeo-platform-query-api/src/test/java/org/nuxeo/ecm/platform/query/api/TestNXQLQueryBuilder.java
@@ -54,11 +54,18 @@ public class TestNXQLQueryBuilder extends SQLRepositoryTestCase {
                 "SELECT * FROM Document WHERE dc:title LIKE 'bar' AND dc:modified IS NULL AND (ecm:parentId = 'foo') ORDER BY dc:title",
                 query);
 
-        // only boolean available in schema withour default value
+        // only boolean available in schema without default value
         model.setPropertyValue("search:isPresent", false);
         query = NXQLQueryBuilder.getQuery(model, whereClause, params, sortInfos);
         assertEquals(
                 "SELECT * FROM Document WHERE dc:title LIKE 'bar' AND dc:modified IS NOT NULL AND (ecm:parentId = 'foo') ORDER BY dc:title",
+                query);
+        
+        query = NXQLQueryBuilder.getQuery("SELECT * FROM ? WHERE ? = '?'",
+                new Object[] { "Document", "dc:title", null },
+                false, true);
+        assertEquals(
+                "SELECT * FROM Document WHERE dc:title = ''",
                 query);
 
     }


### PR DESCRIPTION
Patch for https://jira.nuxeo.com/browse/NXP-10546
